### PR TITLE
added dummy template, routes and views for sponsors page

### DIFF
--- a/pybay/templates/frontend/base.html
+++ b/pybay/templates/frontend/base.html
@@ -48,7 +48,7 @@
                                         <a class="inner-link" href="/">home</a>
                                     </li>
 									<li>
-                                        <a class="inner-link" href="/sponsor" >sponsors</a>
+                                                                            <a class="inner-link" href="{% url 'pybay_sponsors' %}" >sponsors</a>
                                     </li>
                                     <li>
                                         <a class="inner-link" href="/cfp">call for proposals</a>

--- a/pybay/templates/frontend/sponsors.html
+++ b/pybay/templates/frontend/sponsors.html
@@ -1,0 +1,20 @@
+{% extends 'frontend/base.html' %}
+{% load static %}
+
+{% block content %}
+<!--Event Focus Starts -->
+    <a id="about" class="in-page-link"></a>
+
+    <section class="topics duplicatable-content">
+
+        <div class="container">
+	    <h1>I'm the sponsors page, implement me!</h1>
+        </div><!--end of container-->
+    </section>
+    <!--Previous Meetup Ends -->
+{% endblock content %}
+
+
+
+
+

--- a/pybay/urls.py
+++ b/pybay/urls.py
@@ -22,27 +22,26 @@ urlpatterns = patterns(
     url(r"^$", TemplateView.as_view(template_name="frontend/index.html"), name="home"),
     url(r"^admin/", include(admin.site.urls)),
 
-    url(r"^teams/", include(teams_urls)),
-    url(r"^proposals/", include(proposals_urls)),
-    url(r"^sponsors/", include(sponsor_urls)),
+    # url(r"^teams/", include(teams_urls)),
+    # url(r"^proposals/", include(proposals_urls)),
     # url(r"^account/signup/$", SignupView.as_view(), name="account_signup"),
     # url(r"^account/login/$", symposion.views.LoginView.as_view(), name="account_login"),
     url(r"^account/", include("account.urls")),
 
-    url(r"^dashboard/", symposion.views.dashboard, name="dashboard"),
-    url(r"^speaker/", include(speaker_urls)),
+    # url(r"^dashboard/", symposion.views.dashboard, name="dashboard"),
+    # url(r"^speaker/", include(speaker_urls)),
     # url(r"^sponsors/", include("symposion.sponsorship.urls")),
-    url(r"^boxes/", include("pinax.boxes.urls")),
+    # url(r"^boxes/", include("pinax.boxes.urls")),
     # url(r"^teams/", include("symposion.teams.urls")),
-    url(r"^reviews/", include("symposion.reviews.urls")),
-    url(r"^schedule/", include("symposion.schedule.urls")),
-    url(r"^markitup/", include("markitup.urls")),
+    # url(r"^reviews/", include("symposion.reviews.urls")),
+    # url(r"^schedule/", include("symposion.schedule.urls")),
+    # url(r"^markitup/", include("markitup.urls")),
 
-    url(r"^markitup/", include("markitup.urls")),
+    # url(r"^markitup/", include("markitup.urls")),
 
 
+    url(r"^sponsors$", TemplateView.as_view(template_name="frontend/sponsors.html"), name="pybay_sponsors"),
     url(r"^cfp$", pybay_cfp_create, name="pybay_cfp"),
-
     # url(r"^", include("symposion.cms.urls")),
 )
 


### PR DESCRIPTION
I created all the backend infrastructure for the sponsors page. The page is very barebones intentionally so that Onur can port over his sponsors frontend with minimal backend work.

I'm also disabling a series of routes for components we don't need at the moment