### PR TITLE
Deploy staging branch on staging server

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ disk. Eg:
 Install fabric. Then use the `fab` command to run the deploy
 task. You'll need the ssh login password for this.
 
-    $ pip install fabric
+    $ pip install fabric3
     $ fab deploy
     [pyconsf.com] Executing task 'deploy'
     Start with a git checkout.
@@ -44,9 +44,9 @@ task. You'll need the ssh login password for this.
     ... much output...
     Successfully completed
 
-By default the deploy task deploys to staging.pyconsf.com. To deploy
-to production (same server but virtualhost pyconsf.com) run it with
-the prod target as an argument.
+By default the deploy task deploys to staging.pyconsf.com using pybay's
+staging branch.  To deploy master branch to production (same server but
+virtualhost pyconsf.com) run it with the prod target as an argument.
 
     $ fab deploy:prod
     [pyconsf.com] Executing task 'deploy'

--- a/fabfile.py
+++ b/fabfile.py
@@ -19,7 +19,8 @@ def checkout(prod=False):
     run("mkdir %s" % dirname)
     with cd(dirname):
         with hide('running', 'stdout'):
-            run("git clone https://github.com/pybay/pybay.git")
+            clone_args = '' if prod else ' -b staging'
+            run("git clone https://github.com/pybay/pybay.git%s" % clone_args)
     return dirname
 
 def virtualenv(checkout):


### PR DESCRIPTION
So far our fabric file allows to deploy the master branch to both, production and stating server.
This PR allows to deploy the staging branch to the staging server for improved flexibility, decoupling the restriction to commit into master for staging purposes.