### PR TITLE
Remove reference to Simeon's home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ disk. Eg:
 
     $ cd ~/workspace/pybay/ENV/lib/python3.6/site-packages/
     $ rm -rf symposion
-    $ ln -s /Users/sfranklin/workspace/symposion/symposion .
+    $ ln -s ~/workspace/symposion/symposion .
 
 ## Deploying
 


### PR DESCRIPTION
Although the instructions assume that one is working inside of a `workspace`
directory in one's home directory (and this repo checked out inside of that
`workspace` directory), there is a hard-coded reference to `/Users/sfranklin`
that can be removed to match the `~/workspace/pybay...` nomenclature ealier in
the directions.