### PR TITLE
Fixed admin for category to be a dropdown

### DIFF
--- a/pybay/proposals/models.py
+++ b/pybay/proposals/models.py
@@ -46,7 +46,7 @@ class Proposal(ProposalBase):
         default=True,
         help_text="By submitting your proposal, you agree to give permission to the conference organizers to record, edit, and release audio and/or video of your presentation. If you do not agree to this, please uncheck this box."
     )
-    category = models.CharField(max_length=100)
+    category = models.CharField(max_length=100, choices=CATEGORY_CHOICES)
     talk_links = models.CharField(max_length=200)
     what_will_attendees_learn = models.TextField()
     meetup_talk = models.CharField(choices=MEETUP_CHOICES, max_length=100, default="No")


### PR DESCRIPTION
As reported in Trello card:
https://trello.com/c/XWRecgGZ/199-django-admins-category-field-is-a-text-fieldm-not-a-drop-down-any-problem-with-that

@PirosB3 It seems like you worked on the category field last, would you know if there's a problem enabling choices in the model? 