### PR TITLE
Add email and phone to admin talk listing

### DIFF
--- a/pybay/proposals/admin.py
+++ b/pybay/proposals/admin.py
@@ -4,7 +4,12 @@ from .models import TalkProposal, TutorialProposal
 
 
 class TalkProposalAdmin(admin.ModelAdmin):
-    list_display = ('title', 'speaker', 'status')
+    list_display = ('title', 'speaker', 'speaker_email', 'speaker_phone_number', 'status')
+    ordering = ['result__status', 'speaker']
+
+    def speaker_phone_number(self, obj):
+        return obj.speaker.phone_number
+    speaker_phone_number.admin_order_field  = 'speaker__phone_number'
 
 
 admin.site.register(TalkProposal, TalkProposalAdmin)


### PR DESCRIPTION
Make more useful the talk admin page adding email, phone and sorting by talk status