### PR TITLE
Remove the loading screen

### DIFF
--- a/pybay/templates/frontend/base.html
+++ b/pybay/templates/frontend/base.html
@@ -26,14 +26,6 @@
     {% block header %}
     <body>
 
-        <div class="loader">
-            <div class="strip-holder">
-                <div class="strip-1"></div>
-                <div class="strip-2"></div>
-                <div class="strip-3"></div>
-            </div>
-        </div>
-
         <a id="top"></a>
 
         <div class="nav-container">

--- a/static/new/js/scripts.js
+++ b/static/new/js/scripts.js
@@ -340,17 +340,6 @@ $(window).load(function() {
         iFrame.contents().find('form').attr('target', '_blank').submit();
         return false;
     });
-
-    setTimeout(function() {
-        $('.loader').addClass('hide-loader');
-        setTimeout(function() {
-            $('.loader').remove();
-            $('.main-container').addClass('show-content');
-            $('nav').addClass('show-content');
-        }, 500);
-    }, 10);
-
-
 });
 
 //Call For Propositions Form


### PR DESCRIPTION
On my connection when loading the front page, enough content loads by the 500ms mark. This is when the loading screen is able to show up. By that stage, there's enough content loaded for the page to make sense. The loading screen stays on until the 5s mark. It only gets worse on worse connections. By removing the loading screen we sensibly reduce the perceived loading time and allow users to see content sooner. This patch removes the loading screen.