### PR TITLE
Allow talk.abstract to have linebreaks in speakers_detail.html

### DIFF
--- a/pybay/templates/frontend/speakers_detail.html
+++ b/pybay/templates/frontend/speakers_detail.html
@@ -47,7 +47,7 @@
                                 </p>
                                 <p class="lead">
                                     <h3>Abstract</h3>
-                                    {{ talk.abstract }}
+                                    {{ talk.abstract|linebreaks }}
                                 </p>
                             </div>
                     </div>


### PR DESCRIPTION
I submitted my talk Abstract with line breaks, but they're not showing in the site: https://pybay.com/speaker/flavio-juvenal/