### PR TITLE
Added address for Pre-conference workshop venue on registration page

### DIFF
--- a/pybay/templates/frontend/registration.html
+++ b/pybay/templates/frontend/registration.html
@@ -133,7 +133,8 @@
                     <img alt="Venue" src="{% static 'new/img/Question-Mark.jpg' %}">
                     <h3>Pre-Conference Workshops Venue</h3>
                     <p>
-                        TBD
+                        875 Stevenston Street, 5th floor <br/>
+                        San Francisco, CA 94103 
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
#As per Grace's request, on the registration page, I put the address ("875 Stevenston Street, 5th floor, San Francisco, CA 94103") in place of TBD.  This affects the registration.html file. 