### PR TITLE
Use markdown for featured speakers

### DIFF
--- a/pybay/featured_speakers/templates/featured_speakers/list.html
+++ b/pybay/featured_speakers/templates/featured_speakers/list.html
@@ -1,4 +1,5 @@
 {% load get_speaker_url_with_fallback %}
+{% load markup_tags %}
 <div class="row">
     <div class="col-sm-12">
         <h1 class="blue-header"><strong>Some of our speakers</strong></h1>
@@ -19,7 +20,7 @@
         {% endif %}
       </div>
       <span class="speaker-name">{{ featured.speaker.name }}</span>
-      {{ featured.description|safe|linebreaks }}
+      {{ featured.description|apply_markup:"markdown" }}
     </div>
   </div>
   {% endfor %}


### PR DESCRIPTION
Prod doesn't use HTML code at the moment so removing `|safe` doesn't break anything right now