### PR TITLE
Delete duplicated content

### DIFF
--- a/pybay/templates/frontend/coc_reporting.html
+++ b/pybay/templates/frontend/coc_reporting.html
@@ -25,6 +25,7 @@
             <div class="col-md-10 col-md-offset-1">
                 <h1><strong>Attendee Procedure For Handling Harassment</strong></h1>
                 <p>This page has been adapted from <a href="https://us.pycon.org/2016/about/code-of-conduct/harassment-incidents/">PyCon's CoC procedures</a>.</p>
+                <p><strong>These instructions apply to all volunteers and attendees!</strong></p>
                 <ol>
                     <li>
                         Contact either staff personnel Grace Law (<a href="mailto:grace@pybay.com">grace@pybay.com</a>) or Simeon Franklin (<a href="mailto:simeonf@gmail.com">simeonf@gmail.com</a> / 209 846-2151). All staff will also be prepared to handle the incident - just look for a crew member wearing a PyBay CREW shirt! All of our staff members are <a href="/code-of-conduct">informed of the code of conduct policy</a> and guide for handling harassment at the conference. There will be a mandatory staff meeting onsite at the conference when this will be reiterated as well.
@@ -46,6 +47,7 @@
                 </ol>
                 <h1><strong>Staff Procedure For Handling Harassment</strong></h1>
                 <p>This page has been adapted from <a href="https://us.pycon.org/2016/about/code-of-conduct/harassment-incidents/">PyCon's CoC procedures</a>.</p>
+                <p><strong>These instructions apply only to Grace and Simeon!</strong></p>
                 <p>Be sure to have a good understanding of our Code of Conduct policy, which can be found here: <a href="/code-of-conduct">http://www.pybay.com/code-of-conduct</a></p>
                 <p>Also have a good understanding of what is expected from an attendee that wants to report a harassment incident. These guidelines can be found above on this page.</p>
                 <p>Try to get as much of the incident in written form by the reporter. If you cannot, transcribe it yourself as it was told to you. The important information to gather include the following:</p>
@@ -67,16 +69,13 @@
                     <li>If everyone is presently physically safe, involve law enforcement or security only at a victim's request.</li>
                 </ol>
             <p>There are also some guidelines as to what not to do as an initial response:</p>
-                    <ol>
+               <ol>
                     <li>Do not overtly invite them to withdraw the complaint or mention that withdrawal is OK. This suggests that you want them to do so, and is therefore coercive. "If you're OK with it [pursuing the complaint]" suggests that you are by default pursuing it and is not coercive.</li>
                     <li>Do not ask for their advice on how to deal with the complaint. This is a staff responsibility.</li>
                     <li>Do not offer them input into penalties. This is the staff's responsibility.</li>
-                    <li>Ask them "how can I help?"</li>
-                    <li>Provide them with your list of emergency contacts if they need help later.</li>
-                    <li>If everyone is presently physically safe, involve law enforcement or security only at a victim's request.</li>
                 </ol>
                 <p>Once something is reported Grace and Simeon and any available staff should meet. The main objectives of this meeting is to find out the following:</p>
-                    <ol>
+                <ol>
                     <li>What happened?</li>
                     <li>Are we doing anything about it?</li>
                     <li>Who is doing those things?</li>


### PR DESCRIPTION
Template-only edit to delete duplicated content in the Code of Conduct reporting guidelines