### PR TITLE
Add generic-flatblock app and demonstrate usage

### DIFF
--- a/pybay/settings.py
+++ b/pybay/settings.py
@@ -149,6 +149,8 @@ INSTALLED_APPS = [
     "taggit",
     "timezones",
     "columns",
+    'django_generic_flatblocks',
+    'django_generic_flatblocks.contrib.gblocks',
 
 
     # symposion

--- a/pybay/templates/frontend/flatblock.html
+++ b/pybay/templates/frontend/flatblock.html
@@ -1,0 +1,3 @@
+{{ object.text|safe}}
+
+{% if admin_url %}<a href="{{ admin_url }}">edit</a>{% endif %}

--- a/pybay/templates/frontend/registration.html
+++ b/pybay/templates/frontend/registration.html
@@ -15,11 +15,8 @@
         <div class="row">
             <div class="col-md-6 col-sm-6">
                 <div class="topic">
-                    <i class="pe-7s-like2 icon-large"></i>
-                    <h3 class="blue-header"><strong>Corporate Pass</strong></h3>
-                    <p class="lead">
-                         We love employers who support their employees’ continuous education. If your company sends 20% or more of your engineering team or 10 or more developers to PyBay at the corporate rate, we'll feature your company's logo among Python Supporters!</p>
-
+                  {% load generic_flatblocks %}
+                  {% gblock "registration_1st" for "gblocks.Text" with 'frontend/flatblock.html' %}
                 </div>
             </div>
         <div class="col-md-6 col-sm-6">

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ django-appconf==1.0.1
 django-bootstrap-form==3.2.1
 django-columns==0.1.0
 django-crispy-forms==1.6.1
+django-generic-flatblocks==1.1.1
 django-jsonfield==1.0.1
 django-markup==1.2
 django-markitup==2.2.2


### PR DESCRIPTION
I'm adding a flatblock app. As you might suspect from the name flatpages give a single unstructured editable text block, but flatblock lets you have several editable regions on a structured page. I only am including one usage but will go through with Grace and convert all the spots she wants to edit without a github pr.