### PR TITLE
Change web title to PyBay2018

### DIFF
--- a/pybay/templates/frontend/base.html
+++ b/pybay/templates/frontend/base.html
@@ -5,7 +5,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>PyBay2017</title>
+        <title>PyBay2018</title>
         <link rel="shortcut icon" type="image/png" href="{% static 'new/img/pybayfav.ico' %}"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link href="{% static 'new/css/bootstrap.min.css' %}" rel="stylesheet" type="text/css" media="all"/>


### PR DESCRIPTION
The web title is still showing PyBay2018. Changing it will show the right title in google and probably help SEO