### PR TITLE
Remove mailchimp from index.html and use ti.to instead

### DIFF
--- a/pybay/templates/frontend/index.html
+++ b/pybay/templates/frontend/index.html
@@ -273,21 +273,11 @@
                     <h1 class="large-h1" style="color: black;">Subscribe to stay informed</h1>
                 </div>
             </div><!--end of row-->
-            <form action="//pybay.us13.list-manage.com/subscribe/post?u=67e3e75a2e0fe4ee8ceb3e1e7&amp;id=0f17fc9d03" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-                <div class="row">
-                    <div class="col-sm-12 text-center">
-                        <input type="email" value="" name="EMAIL" class="form-email signup-email-field email" id="mce-EMAIL" placeholder="Enter your email address" required>
-                        <div style="position: absolute; left: -5000px;" aria-hidden="true">
-                            <input type="text" name="b_67e3e75a2e0fe4ee8ceb3e1e7_0f17fc9d03" tabindex="-1" value="">
-                        </div>
-                    </div>
-                </div><!--end of row-->
-                <div class="row">
-                    <div class="col-sm-12 text-center">
-                        <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="btn"></div>
-                    </div>
-                </div><!--end of row-->
-            </form>
+		<div class="row">
+		    <div class="col-sm-12 text-center">
+			<div class="clear"><a href="https://ti.to/sf-python/pybay2018" class="btn" target="_blank">Subscribe Here</a></div>
+		    </div>
+		</div><!--end of row-->
         </div>
                 <!--End mc_embed_signup-->
 <!--                <div class="col-md-6 col-md-offset-3 col-sm-8 col-sm-offset-2">


### PR DESCRIPTION
Sorry this isn't coming from a fork, but I want to replace our Mailchimp form with a link to Tito instead to collect email addresses. I'd prefer for us to not have to split interested people between Mailchimp and Tito; the latter seems sufficient and gives us mailing lists by ticket type without additional work, which seems ok. Does this look alright to you?