### PR TITLE
Added two spaces after every line (how to create newline in markdown)

### DIFF
--- a/pybay/proposals/email_confirmation.tmpl
+++ b/pybay/proposals/email_confirmation.tmpl
@@ -15,19 +15,27 @@ Information submitted for this talk proposal
 --------------------------------------------
 
 Name: {first_name} {last_name}
+
 Email: {email}
+
 Phone number: {phone}
-Speaker Profile: {speaker_bio}
+
+Speaker Profile:
+
+{speaker_bio}
 
 --------------------------------------------
 Talk Title: {talk_title}
+
 Themes: {themes}
+
 Level: {audience_level}
+
 Length: {talk_length}
 Description: {description}
 Abstract: {abstract}
-What attendees will learn: {what_attendees_will_learn}
+*What attendees will learn*: {what_attendees_will_learn}
 Speaker and talk history: {speaker_and_talk_history}
 Speaker website: {website}
 Talk links: {links_to_past_talks}
-Meetup talk?: {meetup_talk}
+Meetup talk?: {meetup_talk}  


### PR DESCRIPTION
This is an attempt to clean up formatting issues on Issue 225. However, we may need further formatting. The text (speaker bio,etc) might be rendering without line breaks due to a markdown issue. 