### PR TITLE
Serve site on a single canonical URL

### DIFF
--- a/infrastructure/prod_nginx.conf
+++ b/infrastructure/prod_nginx.conf
@@ -4,6 +4,7 @@ upstream django_prod {
 
 server {
     listen      443 ssl http2;
+    listen      [::]:443 ssl http2;
     server_name pybay.com;
 
     location /site_media {
@@ -20,6 +21,8 @@ server {
 server {
     listen      80;
     listen      443 ssl http2;
+    listen      [::]:80;
+    listen      [::]:443 ssl http2;
     server_name .pyconsf.com
                 .pybay.com;
 

--- a/infrastructure/prod_nginx.conf
+++ b/infrastructure/prod_nginx.conf
@@ -3,11 +3,8 @@ upstream django_prod {
     server unix:////data/websites/prod.sock; }
 
 server {
-    listen      80;
     listen      443 ssl http2;
-    server_name .pyconsf.com
-                .pybay.com;
-
+    server_name pybay.com;
 
     location /site_media {
         alias /data/websites/prod_site_media; }
@@ -18,4 +15,13 @@ server {
 
     charset     utf-8;
     client_max_body_size 75M;
+}
+
+server {
+    listen      80;
+    listen      443 ssl http2;
+    server_name .pyconsf.com
+                .pybay.com;
+
+    return 301 https://pybay.com$request_uri;
 }

--- a/infrastructure/prod_nginx.conf
+++ b/infrastructure/prod_nginx.conf
@@ -4,7 +4,7 @@ upstream django_prod {
 
 server {
     listen      80;
-    listen      443 ssl;
+    listen      443 ssl http2;
     server_name .pyconsf.com
                 .pybay.com;
 

--- a/infrastructure/staging_nginx.conf
+++ b/infrastructure/staging_nginx.conf
@@ -4,6 +4,7 @@ upstream django_staging {
 
 server {
     listen      80;
+    listen      443 ssl;
     server_name staging.pyconsf.com
                 staging.pybay.com;
 

--- a/infrastructure/staging_nginx.conf
+++ b/infrastructure/staging_nginx.conf
@@ -4,6 +4,7 @@ upstream django_staging {
 
 server {
     listen      443 ssl http2;
+    listen      [::]:443 ssl http2;
     server_name staging.pybay.com;
 
     location /site_media {
@@ -19,6 +20,7 @@ server {
 
 server {
     listen      80;
+    listen      [::]:80;
     server_name staging.pybay.com
                 staging.pyconsf.com;
 

--- a/infrastructure/staging_nginx.conf
+++ b/infrastructure/staging_nginx.conf
@@ -3,10 +3,8 @@ upstream django_staging {
     server unix:////data/websites/staging.sock; }
 
 server {
-    listen      80;
     listen      443 ssl http2;
-    server_name staging.pyconsf.com
-                staging.pybay.com;
+    server_name staging.pybay.com;
 
     location /site_media {
         alias /data/websites/staging_site_media; }
@@ -17,4 +15,12 @@ server {
 
     charset     utf-8;
     client_max_body_size 75M;
+}
+
+server {
+    listen      80;
+    server_name staging.pybay.com
+                staging.pyconsf.com;
+
+    return 301 https://staging.pybay.com$request_uri;
 }

--- a/infrastructure/staging_nginx.conf
+++ b/infrastructure/staging_nginx.conf
@@ -4,7 +4,7 @@ upstream django_staging {
 
 server {
     listen      80;
-    listen      443 ssl;
+    listen      443 ssl http2;
     server_name staging.pyconsf.com
                 staging.pybay.com;
 

--- a/pybay/featured_speakers/templates/featured_speakers/list.html
+++ b/pybay/featured_speakers/templates/featured_speakers/list.html
@@ -14,7 +14,7 @@
         {% if featured.speaker.twitter_username %}
         <div class="hover-state text-center preserve3d">
           <div class="social-links vertical-align">
-            <a href="http://twitter.com/{{ featured.speaker.twitter_username }}"><i class="icon social_twitter"></i></a>
+            <a href="https://twitter.com/{{ featured.speaker.twitter_username }}"><i class="icon social_twitter"></i></a>
           </div>
         </div>
         {% endif %}

--- a/pybay/prod_settings.py
+++ b/pybay/prod_settings.py
@@ -14,7 +14,7 @@ DATABASES = {
     }
 }
 
-ALLOWED_HOSTS = ['prod.pyconsf.com', 'pyconsf.com', 'www.pyconsf.com', 'www.pybay.com', 'pybay.com', 'prod.pybay.com']
+ALLOWED_HOSTS = ['pybay.com']
 
 TIME_ZONE = "US/Pacific"
 

--- a/pybay/staging_settings.py
+++ b/pybay/staging_settings.py
@@ -14,7 +14,7 @@ DATABASES = {
     }
 }
 
-ALLOWED_HOSTS = ['staging.pyconfsf.com']
+ALLOWED_HOSTS = ['staging.pybay.com']
 
 CANONICAL_HOST = 'http://staging.pybay.com'
 

--- a/pybay/templates/frontend/coc_reporting.html
+++ b/pybay/templates/frontend/coc_reporting.html
@@ -48,7 +48,7 @@
                 <h1><strong>Staff Procedure For Handling Harassment</strong></h1>
                 <p>This page has been adapted from <a href="https://us.pycon.org/2016/about/code-of-conduct/harassment-incidents/">PyCon's CoC procedures</a>.</p>
                 <p><strong>These instructions apply only to Grace and Simeon!</strong></p>
-                <p>Be sure to have a good understanding of our Code of Conduct policy, which can be found here: <a href="/code-of-conduct">http://www.pybay.com/code-of-conduct</a></p>
+                <p>Be sure to have a good understanding of our Code of Conduct policy, which can be found here: <a href="/code-of-conduct">https://pybay.com/code-of-conduct</a></p>
                 <p>Also have a good understanding of what is expected from an attendee that wants to report a harassment incident. These guidelines can be found above on this page.</p>
                 <p>Try to get as much of the incident in written form by the reporter. If you cannot, transcribe it yourself as it was told to you. The important information to gather include the following:</p>
                 <ol>

--- a/pybay/templates/symposion/emails/proposal_new_message/message.html
+++ b/pybay/templates/symposion/emails/proposal_new_message/message.html
@@ -9,5 +9,5 @@
 </blockquote>
 <p>
     {% if reviewer %}{% url 'review_detail' proposal.pk as detail_url %}{% else %}{% url 'proposal_detail' proposal.pk as detail_url %}{% endif %}
-    {% blocktrans %} Respond online at <a href="http://{{ current_site }}{{ detail_url }}#proposal-feedback">http://{{ current_site }}{{ detail_url }}#proposal-feedback</a>{% endblocktrans %}
+    {% blocktrans %} Respond online at <a href="https://{{ current_site }}{{ detail_url }}#proposal-feedback">https://{{ current_site }}{{ detail_url }}#proposal-feedback</a>{% endblocktrans %}
 </p>

--- a/pybay/templates/symposion/emails/proposal_updated/message.html
+++ b/pybay/templates/symposion/emails/proposal_updated/message.html
@@ -6,5 +6,5 @@
 </p>
 <p>
     {% url 'review_detail' proposal.pk as detail_url %}
-    {% blocktrans %}View the latest version of the proposal online at <a href="http://{{ current_site }}{{ detail_url }}">http://{{ current_site }}{{ detail_url }}</a>{% endblocktrans %}
+    {% blocktrans %}View the latest version of the proposal online at <a href="https://{{ current_site }}{{ detail_url }}">https://{{ current_site }}{{ detail_url }}</a>{% endblocktrans %}
 </p>

--- a/pybay/templates/symposion/emails/speaker_addition/message.html
+++ b/pybay/templates/symposion/emails/speaker_addition/message.html
@@ -5,6 +5,6 @@
     talk proposal for {{ site_name }} entitled "{{ title }}".</p>
 
 <p>For more details, visit the {{ site_name }} speaker dashboard:
-    <a href="http://{{ current_site }}{{ dashboard_url }}">http://{{ current_site }}{{ dashboard_url ]}</a>
+    <a href="https://{{ current_site }}{{ dashboard_url }}">https://{{ current_site }}{{ dashboard_url ]}</a>
 </p>
 {% endblocktrans %}

--- a/pybay/templates/symposion/emails/speaker_invite/message.html
+++ b/pybay/templates/symposion/emails/speaker_invite/message.html
@@ -6,7 +6,7 @@
 
 <p>Go to</p>
 
-<p><a href="http://{{ current_site }}{{ token_url }}">http://{{ current_site }}{{ token_url }}</a></p>
+<p><a href="https://{{ current_site }}{{ token_url }}">https://{{ current_site }}{{ token_url }}</a></p>
 
 <p>to confirm.</p>
 

--- a/pybay/templates/symposion/emails/speaker_no_profile/message.html
+++ b/pybay/templates/symposion/emails/speaker_no_profile/message.html
@@ -6,7 +6,7 @@
 
 <p>Go to</p>
 
-<p><a href="http://{{ current_site }}{{ token_url }}">http://{{ current_site }}{{ token_url }}</a></p>
+<p><a href="https://{{ current_site }}{{ token_url }}">https://{{ current_site }}{{ token_url }}</a></p>
 
 <p>to confirm and fill out your speaker profile.</p>
 {% endblocktrans %}

--- a/pybay/templates/symposion/emails/teams_user_applied/message.html
+++ b/pybay/templates/symposion/emails/teams_user_applied/message.html
@@ -7,6 +7,6 @@
 
     <p>
         To accept this application and see any other pending applications, visit the following url:
-        <a href="http://{{ site_url }}{{ team_url }}">http://{{ site_url }}{{ team_url }}</a>
+        <a href="https://{{ site_url }}{{ team_url }}">https://{{ site_url }}{{ team_url }}</a>
     </p>
 {% endblocktrans %}

--- a/pybay/templates/symposion/emails/teams_user_invited/message.html
+++ b/pybay/templates/symposion/emails/teams_user_invited/message.html
@@ -7,6 +7,6 @@
 
     <p>
         To accept this invitation, visit the following url:
-        <a href="http://{{ site_url }}{{ team_url }}">http://{{ site_url }}{{ team_url }}</a>
+        <a href="https://{{ site_url }}{{ team_url }}">https://{{ site_url }}{{ team_url }}</a>
     </p>
 {% endblocktrans %}


### PR DESCRIPTION
Sorry, a few things tied into one PR:
1. Redirect non-HTTPS to HTTPS
1. Redirect non-canonical hostnames to pybay.com
1. Listen on IPv6
1. Only link to the site on `https`
1. Enable http/2

These all relate to each other in that they are the result of the same set of changes to the nginx vhosts, or are prerequisites for redirecting http to https.