### PR TITLE
Enable HSTS with 1-year TTL

### DIFF
--- a/infrastructure/prod_nginx.conf
+++ b/infrastructure/prod_nginx.conf
@@ -16,6 +16,7 @@ server {
 
     charset     utf-8;
     client_max_body_size 75M;
+    add_header Strict-Transport-Security "max-age=31536000" always;
 }
 
 server {

--- a/infrastructure/staging_nginx.conf
+++ b/infrastructure/staging_nginx.conf
@@ -16,6 +16,7 @@ server {
 
     charset     utf-8;
     client_max_body_size 75M;
+    add_header Strict-Transport-Security "max-age=31536000" always;
 }
 
 server {


### PR DESCRIPTION
Following on from #249, let's declare that we'll always be https only.

Browsers cache this and never attempt to visit the site on http. So, this is something we can't really go back on.

I've put this on the current staging site and progcom, with a TTL of 1 day.
