### PR TITLE
The .pybay.com was being masked by the port 443 server

### DIFF
--- a/infrastructure/prod_nginx.conf
+++ b/infrastructure/prod_nginx.conf
@@ -20,11 +20,8 @@ server {
 
 server {
     listen      80;
-    listen      443 ssl http2;
     listen      [::]:80;
-    listen      [::]:443 ssl http2;
-    server_name .pyconsf.com
-                .pybay.com;
+    server_name pybay.com;
 
     return 301 https://pybay.com$request_uri;
 }


### PR DESCRIPTION
Instead, let's move the redirects into a separate nginx server,
`/etc/nginx/sites-enabled/default-redirect.conf`