### PR TITLE
Add redirects app and make Tickets page redirect to tito.

### DIFF
--- a/pybay/settings.py
+++ b/pybay/settings.py
@@ -113,6 +113,7 @@ MIDDLEWARE_CLASSES = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.contrib.flatpages.middleware.FlatpageFallbackMiddleware",
+    "django.contrib.redirects.middleware.RedirectFallbackMiddleware",
 ]
 
 ROOT_URLCONF = "pybay.urls"
@@ -132,6 +133,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "django.contrib.humanize",
     "django.contrib.flatpages",
+    "django.contrib.redirects",
 
     # theme
     "bootstrapform",

--- a/pybay/urls.py
+++ b/pybay/urls.py
@@ -29,7 +29,7 @@ urlpatterns = [
     url(r'^sponsors/$', RedirectView.as_view(pattern_name='pybay_sponsors', permanent=False)),
     url(r"^code-of-conduct$", TemplateView.as_view(template_name="frontend/code_of_conduct.html"), name="pybay_coc"),
     url(r"^coc-reporting$", TemplateView.as_view(template_name="frontend/coc_reporting.html"), name="pybay_coc_reporting"),
-    url(r"^registration$", faq_view(template_name="frontend/registration.html", faq_filter="show_on_registration"), name="pybay_tickets"),
+    url(r"^registration$", RedirectView.as_view(url='https://ti.to/sf-python/pybay2018')),
     url(r"^faq$", views.pybay_faq_index, name="pybay_faq"),
 
     url(r"^admin/", include(admin.site.urls)),


### PR DESCRIPTION
The redirects app is a fallback for 404s and will 302 if a path is registered. I don't want to have /registration 404 so I've turned it into a 302 to the tito site for the time being. Once we register it in `redirects`, we can drop the url.

We'll have to migrate production to add the redirect tables, but I think we run migrations automatically with fab.