### PR TITLE
Make countdowns render horizontally

### DIFF
--- a/static/pybay/sass/pages/frontpage/_video.scss
+++ b/static/pybay/sass/pages/frontpage/_video.scss
@@ -1,6 +1,5 @@
 
 .video-tagline, .video-moreinfo {
-  display: block;
   color: white;
   font-weight: 300;
 }


### PR DESCRIPTION
Remove `display: block` from `.video-moreinfo`. I have no idea why it is there, or why the countdown is tagged `video-moreinfo`, but this doesn't seem to be used anywhere else, and it does solve the problem.