### PR TITLE
Don't strip HTML from talk abstracts

### DIFF
--- a/pybay/templates/frontend/speakers_detail.html
+++ b/pybay/templates/frontend/speakers_detail.html
@@ -1,12 +1,11 @@
 {% extends 'frontend/base.html' %}
 {% load staticfiles %}
 {% load thumbnail %}
+{% block body_class %}speaker-page{% endblock %}
 {% block content %}
 {% load get_speaker_url_with_fallback %}
 {% load slot_desc %}
 {% load markup_tags %}
-
-{% block body_class %}speaker-page{% endblock %}
 
 <section>
    <div class="container" style="padding-top: 150px;">

--- a/pybay/templates/frontend/speakers_detail.html
+++ b/pybay/templates/frontend/speakers_detail.html
@@ -51,7 +51,7 @@
                                 </div>
                                 <div class="lead">
                                     <h3>Abstract</h3>
-                                    {{ talk.abstract|apply_markup:"markdown" }}
+                                    {{ talk.abstract_html|safe }}
                                 </div>
                                 {% if talk.ticket_price %}
                                 <div class="lead">


### PR DESCRIPTION
#264 did this for the speakers list page, but not speaker detail pages.