### PR TITLE
Put some some space around the theme bullets

### DIFF
--- a/static/pybay/sass/pages/_schedule.scss
+++ b/static/pybay/sass/pages/_schedule.scss
@@ -172,7 +172,6 @@
   }
 
   .sch-timeslot-slot .sch-speaker {
-    margin-right: 1.4em;
     margin-bottom: 0;
   }
 
@@ -190,8 +189,6 @@
   }
 
   .sch-timeslot-slot .sch-category::before {
-    position: absolute;
-    right: 100%;
     content: "\2022";
     padding: 0 .5em;
   }


### PR DESCRIPTION
Don't make them overlap the content before them, like they currently do:

![image](https://user-images.githubusercontent.com/442117/42129573-65b23d3a-7c7d-11e8-9208-39c3872037f0.png)
