### PR TITLE
Simeon/missing sponsors

### DIFF
--- a/pybay/templates/frontend/sponsor_level_list.html
+++ b/pybay/templates/frontend/sponsor_level_list.html
@@ -1,3 +1,4 @@
+{% load sponsors_list %}
 {% if sponsors %}
   <div class="sl-group {{ color }}-sponsors">
 
@@ -17,7 +18,9 @@
             <div class="sl-sponsor">
               <div class="sl-blurb">
                 <a class="sl-logo" href="{{ sponsor.external_url }}" target="_blank" rel="noopener noreferrer">
-                  <img alt="{{ sponsor.name }}" src="{{ sponsor.website_logo.url }}" width="200px" />
+                  {% if sponsor|get_logo %}
+                  <img alt="{{ sponsor.name }}" src="{{ sponsor|get_logo }}" width="200px" />
+                  {% endif %}
                 </a>
                 <p class="sl-intro">{{ sponsor.listing_text|urlize|linebreaks }}</p>
               </div>

--- a/pybay/templatetags/sponsors_list.py
+++ b/pybay/templatetags/sponsors_list.py
@@ -11,3 +11,20 @@ def sponsors_footer(context):
     return {
         'sponsors': sponsors,
     }
+
+
+@register.filter
+def get_logo(sponsor):
+    """Copied and modified from symposion.sponsorship.models.Sponsor - set object.sponsor_logo if not set."""
+    if sponsor.sponsor_logo is None:
+        benefits = sponsor.sponsor_benefits.filter(benefit__type__in=["weblogo", "simple"], upload__isnull=False)
+        for benefit in benefits:
+            if benefit.upload:
+                sponsor.sponsor_logo = benefit
+                sponsor.save()
+                break  # Only do this for the first upload on a benefit
+    # Never crash due to missing logo!
+    if getattr(sponsor.sponsor_logo, 'upload', None):
+        return sponsor.sponsor_logo.upload.url
+    else:
+      return ""


### PR DESCRIPTION
Some sponsors are not showing up. On investigation its because of missing logos which must be attached to a related field (sponsorbenefit) of a certain type. 

Fixed by adding a templatetag which attempts to find the logo by looking at more related records but on failure just returns an empty string instead of crashing.